### PR TITLE
fix(warnings): satisfy compiler on SM 1.13

### DIFF
--- a/addons/sourcemod/scripting/FixFuncRotating.sp
+++ b/addons/sourcemod/scripting/FixFuncRotating.sp
@@ -11,13 +11,14 @@ public Plugin myinfo =
 	name = "FixFuncRotating",
 	author = "Cloud Strife",
 	description = "Fixes func_rotating`s StartForward and StopAtStartPos inputs",
-	version = "1.0.0",
+	version = "1.0.1",
 	url = ""
 };
 
 Handle g_CFuncRotating_StartForward = null;
 Handle g_CFuncRotating_UpdateSpeed = null;
 
+#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR < 13
 stock float FloatMod(float num, float denom)
 {
     return num - denom * RoundToFloor(num / denom);
@@ -27,6 +28,7 @@ stock float operator%(float oper1, float oper2)
 {
     return FloatMod(oper1, oper2);
 }
+#endif
 
 // Set m_bStopAtStartPos to false
 public MRESReturn CFuncRotating_InputStartForward(int entity)


### PR DESCRIPTION
https://github.com/alliedmodders/sourcemod/commit/5539484f9294e539cb7d570872a23f617a7b8b46
Prevent have this error: 
```
FixFuncRotating/addons/sourcemod/scripting/FixFuncRotating.sp(24) : error 021: symbol already defined: "FloatMod"
    24 | stock float FloatMod(float num, float denom)
---------------------^

1 Error.
```